### PR TITLE
Swift 2.0 fixes

### DIFF
--- a/DTIActivityIndicator.xcodeproj/project.pbxproj
+++ b/DTIActivityIndicator.xcodeproj/project.pbxproj
@@ -194,7 +194,9 @@
 		25FC0C6B1A04318500F61053 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = dtissera;
 				TargetAttributes = {
 					25FC0C731A04318500F61053 = {
@@ -301,6 +303,7 @@
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -375,6 +378,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dtissera.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -390,6 +394,7 @@
 				INFOPLIST_FILE = "$(SRCROOT)/Source/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dtissera.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -408,6 +413,7 @@
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dtissera.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -421,6 +427,7 @@
 				);
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.dtissera.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/Source/DTIActivityIndicatorView.swift
+++ b/Source/DTIActivityIndicatorView.swift
@@ -40,7 +40,7 @@ public class DTIActivityIndicatorView: UIView {
         super.init(frame: frame);
     }
     
-    required public init(coder aDecoder: NSCoder) {
+    required public init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
     }
     
@@ -99,7 +99,7 @@ public class DTIActivityIndicatorView: UIView {
             
             var arrayOfDashLength: [CGFloat] = [2.0, 2.0]
             CGContextSetStrokeColorWithColor(context, self.indicatorColor.CGColor)
-            var dash = { (phase: CGFloat, lengths: UnsafePointer<CGFloat>, count: Int) -> Void in
+            let dash = { (phase: CGFloat, lengths: UnsafePointer<CGFloat>, count: Int) -> Void in
                 CGContextSetLineDash(context, phase, lengths, count)
             }
             dash(0.0, arrayOfDashLength, arrayOfDashLength.count)

--- a/Source/DTIAnimChasingDots.swift
+++ b/Source/DTIAnimChasingDots.swift
@@ -84,7 +84,7 @@ class DTIAnimChasingDots: DTIAnimProtocol {
         ]
         aniScale1.duration = self.animationDuration
         
-        var aniScale2 = CAKeyframeAnimation()
+        let aniScale2 = CAKeyframeAnimation()
         aniScale2.keyPath = "transform.scale"
         aniScale2.values = [0, 1, 0]
         aniScale2.removedOnCompletion = false

--- a/Source/DTIAnimDoubleBounce.swift
+++ b/Source/DTIAnimDoubleBounce.swift
@@ -29,7 +29,6 @@ class DTIAnimDoubleBounce: DTIAnimProtocol {
     func needLayoutSubviews() {
         self.spinnerView.frame = self.owner.bounds
         
-        let contentSize = self.owner.bounds.size
         let doubleBounceSize = CGRectInset(self.owner.bounds, 2.0, 2.0).size
 
         self.doubleBounce1View.frame = CGRectMake(0.0, 0.0, doubleBounceSize.width, doubleBounceSize.height)
@@ -73,7 +72,7 @@ class DTIAnimDoubleBounce: DTIAnimProtocol {
         ]
         aniScale1.duration = self.animationDuration
         
-        var aniScale2 = CAKeyframeAnimation()
+        let aniScale2 = CAKeyframeAnimation()
         aniScale2.keyPath = "transform.scale"
         aniScale2.values = [0, 1, 0]
         aniScale2.removedOnCompletion = false

--- a/Source/DTIAnimPulse.swift
+++ b/Source/DTIAnimPulse.swift
@@ -28,7 +28,6 @@ class DTIAnimPulse: DTIAnimProtocol {
     func needLayoutSubviews() {
         self.spinnerView.frame = self.owner.bounds
         
-        let contentSize = self.owner.bounds.size
         let pulseViewSize = CGRectInset(self.owner.bounds, 2.0, 2.0).size
         
         self.pulseView.frame = CGRectMake(0.0, 0.0, pulseViewSize.width, pulseViewSize.height)

--- a/Source/DTIAnimRotatingPlane.swift
+++ b/Source/DTIAnimRotatingPlane.swift
@@ -33,8 +33,6 @@ class DTIAnimRotatingPlane: DTIAnimProtocol {
     func needLayoutSubviews() {
         self.spinnerView.frame = self.owner.bounds
         
-        let contentSize = self.owner.bounds.size
-        let sz = contentSize.width*3/5
         self.planeView.frame = CGRectInset(self.owner.bounds, 2.0, 2.0);
     }
     
@@ -50,7 +48,7 @@ class DTIAnimRotatingPlane: DTIAnimProtocol {
     func startActivity() {
         self.owner.addSubview(self.spinnerView)
         
-        var anim = CAKeyframeAnimation()
+        let anim = CAKeyframeAnimation()
         anim.keyPath = "transform"
         anim.removedOnCompletion = false
         anim.repeatCount = HUGE

--- a/Source/DTIAnimSpotify.swift
+++ b/Source/DTIAnimSpotify.swift
@@ -43,7 +43,7 @@ class DTIAnimSpotify: DTIAnimProtocol {
         // self.spinnerView.layer.cornerRadius = circleWidth/2
         
         for var index = 0; index < circleCount; ++index {
-            let circleLayer = self.circleView.layer.sublayers[index] as! CALayer
+            let circleLayer = self.circleView.layer.sublayers![index] as CALayer
             circleLayer.frame = CGRect(x: circleWidth+CGFloat(index)*(circleWidth*2), y: posY, width: circleWidth, height: circleWidth)
             
             circleLayer.cornerRadius = circleWidth/2
@@ -56,7 +56,7 @@ class DTIAnimSpotify: DTIAnimProtocol {
         // self.spinnerView.backgroundColor = UIColor.grayColor()
 
         for var index = 0; index < circleCount; ++index {
-            let circleLayer = self.circleView.layer.sublayers[index] as! CALayer
+            let circleLayer = self.circleView.layer.sublayers![index] as CALayer
             circleLayer.backgroundColor = self.owner.indicatorColor.CGColor
         }
     }
@@ -71,7 +71,7 @@ class DTIAnimSpotify: DTIAnimProtocol {
 
         let beginTime = CACurrentMediaTime() + self.animationDuration;
         for var index = 0; index < circleCount; ++index {
-            let circleLayer = self.circleView.layer.sublayers[index] as! CALayer
+            let circleLayer = self.circleView.layer.sublayers![index] as CALayer
             
             let aniScale = CAKeyframeAnimation()
             aniScale.keyPath = "transform.scale"
@@ -96,7 +96,7 @@ class DTIAnimSpotify: DTIAnimProtocol {
         func removeAnimations() {
             self.spinnerView.layer.removeAllAnimations()
             for var index = 0; index < circleCount; ++index {
-                let circleLayer = self.circleView.layer.sublayers[index] as! CALayer
+                let circleLayer = self.circleView.layer.sublayers![index] as CALayer
                 circleLayer.removeAllAnimations()
             }
             

--- a/Source/DTIAnimWanderingCubes.swift
+++ b/Source/DTIAnimWanderingCubes.swift
@@ -36,7 +36,7 @@ class DTIAnimWanderingCubes: DTIAnimProtocol {
         let cubeSize = CGFloat(floor(self.owner.bounds.width / 3.5))
         
         for var index = 0; index < cubeCount; ++index {
-            let layer = self.spinnerView.layer.sublayers[index] as! CALayer
+            let layer = self.spinnerView.layer.sublayers![index] as CALayer
             
             layer.frame = CGRect(x: 0.0, y: 0.0, width: cubeSize, height: cubeSize)
         }
@@ -47,7 +47,7 @@ class DTIAnimWanderingCubes: DTIAnimProtocol {
         // self.spinnerView.backgroundColor = UIColor.grayColor()
         
         for var index = 0; index < cubeCount; ++index {
-            let cubeLayer = self.spinnerView.layer.sublayers[index] as! CALayer
+            let cubeLayer = self.spinnerView.layer.sublayers![index] as CALayer
             cubeLayer.backgroundColor = self.owner.indicatorColor.CGColor
         }
     }
@@ -62,7 +62,7 @@ class DTIAnimWanderingCubes: DTIAnimProtocol {
         
         let beginTime = CACurrentMediaTime();
         for var index = 0; index < cubeCount; ++index {
-            let cubeLayer = self.spinnerView.layer.sublayers[index] as! CALayer
+            let cubeLayer = self.spinnerView.layer.sublayers![index] as CALayer
             let translation = self.spinnerView.bounds.size.width-cubeLayer.bounds.size.width
             
             let aniTransform = CAKeyframeAnimation(keyPath: "transform")
@@ -79,7 +79,7 @@ class DTIAnimWanderingCubes: DTIAnimProtocol {
                 CAMediaTimingFunction(name: kCAMediaTimingFunctionEaseInEaseOut)
             ]
             
-            var transform0 = CATransform3DIdentity;
+            let transform0 = CATransform3DIdentity;
             
             // -90°
             var transform1 = CATransform3DMakeTranslation(translation, 0.0, 0.0);
@@ -119,7 +119,7 @@ class DTIAnimWanderingCubes: DTIAnimProtocol {
             self.spinnerView.layer.removeAllAnimations()
             
             for var index = 0; index < cubeCount; ++index {
-                let layer = self.spinnerView.layer.sublayers[index] as! CALayer
+                let layer = self.spinnerView.layer.sublayers![index] as CALayer
                 layer.removeAllAnimations()
             }
             

--- a/Source/DTIAnimWave.swift
+++ b/Source/DTIAnimWave.swift
@@ -42,7 +42,7 @@ class DTIAnimWave: DTIAnimProtocol {
         self.rectView.frame = self.owner.bounds;
 
         for var index = 0; index < rectCount; ++index {
-            let rectLayer = self.rectView.layer.sublayers[index] as! CALayer
+            let rectLayer = self.rectView.layer.sublayers![index] as CALayer
             rectLayer.frame = CGRect(x: CGFloat(index)*(rectWidth+spaceBetweenRect), y: 0.0, width: rectWidth, height: contentSize.height)
         }
     }
@@ -52,7 +52,7 @@ class DTIAnimWave: DTIAnimProtocol {
         // self.spinnerView.backgroundColor = UIColor.grayColor()
         
         for var index = 0; index < rectCount; ++index {
-            let rectLayer = self.rectView.layer.sublayers[index] as! CALayer
+            let rectLayer = self.rectView.layer.sublayers![index] as CALayer
             rectLayer.backgroundColor = self.owner.indicatorColor.CGColor
         }
     }
@@ -67,7 +67,7 @@ class DTIAnimWave: DTIAnimProtocol {
         
         let beginTime = CACurrentMediaTime() + self.animationDuration;
         for var index = 0; index < rectCount; ++index {
-            let rectLayer = self.rectView.layer.sublayers[index]as! CALayer
+            let rectLayer = self.rectView.layer.sublayers![index] as CALayer
 
             let aniScale = CAKeyframeAnimation()
             aniScale.keyPath = "transform"
@@ -97,7 +97,7 @@ class DTIAnimWave: DTIAnimProtocol {
         func removeAnimations() {
             self.spinnerView.layer.removeAllAnimations()
             for var index = 0; index < rectCount; ++index {
-                let rectLayer = self.rectView.layer.sublayers[index] as! CALayer
+                let rectLayer = self.rectView.layer.sublayers![index] as CALayer
                 rectLayer.removeAllAnimations()
             }
             

--- a/Source/DTIAnimWp8.swift
+++ b/Source/DTIAnimWp8.swift
@@ -40,8 +40,8 @@ class DTIAnimWp8: DTIAnimProtocol {
         let ballSize = CGFloat(self.owner.bounds.width / 9)
         
         for var index = 0; index < ballCount; ++index {
-            let layer = self.spinnerView.layer.sublayers[index] as! CALayer
-            let layerBall = layer.sublayers[0] as! CALayer
+            let layer = self.spinnerView.layer.sublayers![index] as CALayer
+            let layerBall = layer.sublayers![0] as CALayer
             
             layer.frame = self.owner.bounds
             layerBall.frame = CGRect(x: ballSize, y: ballSize, width: ballSize, height: ballSize)
@@ -54,9 +54,9 @@ class DTIAnimWp8: DTIAnimProtocol {
         // Debug stuff
         // self.spinnerView.backgroundColor = UIColor.grayColor()
         
-        for item in self.spinnerView.layer.sublayers {
-            let layer = item as! CALayer
-            let layerBall = layer.sublayers[0] as! CALayer
+        for item in self.spinnerView.layer.sublayers! {
+            let layer = item as CALayer
+            let layerBall = layer.sublayers![0] as CALayer
             
             //layer.backgroundColor = UIColor.grayColor().CGColor
             layerBall.backgroundColor = self.owner.indicatorColor.CGColor
@@ -73,7 +73,7 @@ class DTIAnimWp8: DTIAnimProtocol {
         let beginTime = CACurrentMediaTime();
         let delays = [CFTimeInterval(1.56), CFTimeInterval(0.31), CFTimeInterval(0.62), CFTimeInterval(0.94), CFTimeInterval(1.25)]
         for var index = 0; index < ballCount; ++index {
-            let layer = self.spinnerView.layer.sublayers[index] as! CALayer
+            let layer = self.spinnerView.layer.sublayers![index] as CALayer
             
             let anim = CAKeyframeAnimation(keyPath: "transform.rotation.z")
             anim.duration = self.animationDuration
@@ -123,7 +123,7 @@ class DTIAnimWp8: DTIAnimProtocol {
             self.spinnerView.layer.removeAllAnimations()
 
             for var index = 0; index < ballCount; ++index {
-                let layer = self.spinnerView.layer.sublayers[index] as! CALayer
+                let layer = self.spinnerView.layer.sublayers![index] as CALayer
                 layer.removeAllAnimations()
             }
             

--- a/Source/DTIIndicatorStyle.swift
+++ b/Source/DTIIndicatorStyle.swift
@@ -8,26 +8,26 @@
 
 import Foundation
 
-enum DTIIndicatorStyle: Int {
+public enum DTIIndicatorStyle: Int {
     case rotatingPane, doubleBounce, wave, wanderingCubes, chasingDots, pulse, spotify, wp8
     
-    static let defaultValue = DTIIndicatorStyle.chasingDots
+    public static let defaultValue = DTIIndicatorStyle.chasingDots
     
-    static func conv(value: String) -> DTIIndicatorStyle {
+    public static func conv(value: String) -> DTIIndicatorStyle {
         switch value {
-        case "rotatingPane": return .rotatingPane
-        case "doubleBounce": return .doubleBounce
-        case "wave": return .wave
-        case "wanderingCubes": return .wanderingCubes
-        case "chasingDots": return .chasingDots
-        case "pulse": return .pulse
-        case "spotify": return .spotify
-        case "wp8": return .wp8
-        default: return defaultValue
+            case "rotatingPane": return .rotatingPane
+            case "doubleBounce": return .doubleBounce
+            case "wave": return .wave
+            case "wanderingCubes": return .wanderingCubes
+            case "chasingDots": return .chasingDots
+            case "pulse": return .pulse
+            case "spotify": return .spotify
+            case "wp8": return .wp8
+            default: return defaultValue
         }
     }
     
-    static func convInv(value: DTIIndicatorStyle) -> String {
+    public static func convInv(value: DTIIndicatorStyle) -> String {
         switch value {
             case .rotatingPane: return "rotatingPane"
             case .doubleBounce: return "doubleBounce"
@@ -55,15 +55,15 @@ extension DTIIndicatorStyle {
 */
 extension DTIIndicatorStyle : StringLiteralConvertible {
     
-    init(stringLiteral v : String) {
+    public init(stringLiteral v : String) {
         self = DTIIndicatorStyle.conv(v)
     }
     
-    init(unicodeScalarLiteral v : String) {
+    public init(unicodeScalarLiteral v : String) {
         self = DTIIndicatorStyle.conv(v)
     }
     
-    init(extendedGraphemeClusterLiteral v: String) {
+    public init(extendedGraphemeClusterLiteral v: String) {
         self = DTIIndicatorStyle.conv(v)
     }
     

--- a/Source/DTIIndicatorStyle.swift
+++ b/Source/DTIIndicatorStyle.swift
@@ -29,15 +29,14 @@ enum DTIIndicatorStyle: Int {
     
     static func convInv(value: DTIIndicatorStyle) -> String {
         switch value {
-        case .rotatingPane: return "rotatingPane"
-        case .doubleBounce: return "doubleBounce"
-        case .wave: return "wave"
-        case .wanderingCubes: return "wanderingCubes"
-        case .chasingDots: return "chasingDots"
-        case .pulse: return "pulse"
-        case .spotify: return "spotify"
-        case .wp8: return "wp8"
-        default: return "?"
+            case .rotatingPane: return "rotatingPane"
+            case .doubleBounce: return "doubleBounce"
+            case .wave: return "wave"
+            case .wanderingCubes: return "wanderingCubes"
+            case .chasingDots: return "chasingDots"
+            case .pulse: return "pulse"
+            case .spotify: return "spotify"
+            case .wp8: return "wp8"
         }
     }
 }

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.dtissera.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.dtissera.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
# Done:
- Removed unused initializations
- Replaced some `var` to `let`
- Correctly «force» unwrapping the layers array
- Removed unnecessary `?` in some unwrappings

---

This `PR` is just to keep it out there for when `Swift 2.0` hits production.

There was no major code changes to `Swift 2.0` only running the migrator and then fixing some warnings and errors.

I added this because I needed it compiling in 2.0 for a project I'm working on; hopefully this can be «merged» to its own `swift-2.0` branch in case someone else needs it.
